### PR TITLE
Restrict aiomcache to versions < 0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'redis:python_version<"3.7"': ['aioredis>=0.3.3'],
         'redis:python_version>="3.8"': ['aioredis>=1.3.0'],
         'redis:python_version>="3.7" and python_version<"3.8"': ['aioredis>=1.0.0'],
-        'memcached': ['aiomcache>=0.5.2'],
+        'memcached': ['aiomcache>=0.5.2, < 0.7.0'],
         'msgpack': ['msgpack>=0.5.5'],
         'dev': [
             'asynctest>=0.11.0',


### PR DESCRIPTION
aiomcache version 0.7.0 breaks aiocache[memcached] in Python 3.8 and probably others.